### PR TITLE
Revert "Add permissions to  package_build_artifacts.yaml"

### DIFF
--- a/.github/workflows/package_build_artifacts.yaml
+++ b/.github/workflows/package_build_artifacts.yaml
@@ -7,9 +7,6 @@ on:
   repository_dispatch:
     types: [obs-package]
 
-permissions:
-  contents: write
-  
 jobs:
   zthin_tarball:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts openmainframeproject/build-feilong#3 because this did not work.