### PR TITLE
Add signoff option for commit by gh action

### DIFF
--- a/.github/workflows/package_build_artifacts.yaml
+++ b/.github/workflows/package_build_artifacts.yaml
@@ -127,5 +127,5 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
-          git commit -m "Updated tarballs "
+          git commit -s -m "Updated tarballs "
           git push


### PR DESCRIPTION
DCO signoff was enabled for all commits to build-feilong.  This also affects the github action that commits and pushes the obs-artifacts.

Signed-off-by: Mike Friesenegger <mikef@suse.com>