### PR TITLE
Add qclib for zvmsdk deb

### DIFF
--- a/sdkdeb/control
+++ b/sdkdeb/control
@@ -10,7 +10,7 @@ X-Python-Version: >= 3.12.3
 Package: zvmsdk
 Architecture: all
 # Suggests: zvmsdk-doc
-Depends: python3 (>= 3.12), python3-netaddr (>= 0.7.5), python3-jwt(>= 1.0.1), python3-mock, python3-requests(>= 2.6.0), python3-routes(>= 2.2), python3-webob(>= 1.2.3), python3-jsonschema(>= 2.3.0), python3-six(>= 1.9.0), python3-jinja2, zthin (>= 3.1.0), apache2, libapache2-mod-wsgi-py3
+Depends: python3 (>= 3.12), python3-netaddr (>= 0.7.5), python3-jwt(>= 1.0.1), python3-mock, python3-requests(>= 2.6.0), python3-routes(>= 2.2), python3-webob(>= 1.2.3), python3-jsonschema(>= 2.3.0), python3-six(>= 1.9.0), python3-jinja2, zthin (>= 3.1.0), apache2, libapache2-mod-wsgi-py3, qclib, bsdextrautils
 Description: z/VM cloud connector
  The System z/VM cloud connector is a set of APIs to be used
  by external API consumer.


### PR DESCRIPTION
Added the qclib dependency in the control file under the sdk deb sub directory.

This is done to fix the missing 'zhypinfo'